### PR TITLE
Upgrade to 2.4.1 & upgrade org.gnome.(Platform|Sdk) to 3.26

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -136,8 +136,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.4.0/darktable-2.4.0.tar.xz",
-                    "sha256": "9d37388aee79d5ada71062bbac3cda612a61d1a781f6320b784b27308f3a1878"
+                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.4.1/darktable-2.4.1.tar.xz",
+                    "sha256": "6254c63f9b50894b3fbf431d98c0fe8ec481957ab91f9af76e33cc1201c29704"
                 }
             ]
         }

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.darktable.Darktable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "darktable",
     "rename-desktop-file": "darktable.desktop",


### PR DESCRIPTION
The following pr:
* Updates darktable to [2.4.1](https://github.com/darktable-org/darktable/releases/tag/release-2.4.1)
* Updates `org.gnome.Platform` and `org.gnome.Sdk` to version 3.26