### PR TITLE
Add network permission to enable export to online services

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -9,6 +9,7 @@
     "rename-icon": "darktable",
     "finish-args": [
         "--share=ipc",
+        "--share=network",
         "--socket=x11",
         "--filesystem=host",
         "--talk-name=org.freedesktop.secrets",


### PR DESCRIPTION
As reported by Joel Brunetti in https://www.mail-archive.com/darktable-dev@lists.darktable.org/msg02984.html, this permission seems to be necessary to enable export to online services (Google Photos, Facebook etc.)