### PR TITLE
Bump liblensfun and exiv2 versions

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -68,7 +68,7 @@
                     "type": "git",
                     "url": "https://git.code.sf.net/p/lensfun/code",
                     "branch": "master",
-                    "commit": "b6676773a6bff40a838d8b3da259fcf9b486fa35"
+                    "commit": "505fc47dd2b7cf3769c3e6f4308872f8dcbbdea8"
                 }
             ]
         },
@@ -78,8 +78,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://www.exiv2.org/exiv2-0.25.tar.gz",
-                    "sha256": "c80bfc778a15fdb06f71265db2c3d49d8493c382e516cb99b8c9f9cbde36efa4"
+                    "url": "http://www.exiv2.org/builds/exiv2-0.26-trunk.tar.gz",
+                    "sha256": "c75e3c4a0811bf700d92c82319373b7a825a2331c12b8b37d41eb58e4f18eafb"
                 }
             ]
         },


### PR DESCRIPTION
- Bump liblensfun to latest master
- Bump exiv2 to version 0.26

A test build ran through successfully, and the resulting package worked after installing it locally.