### PR TITLE
Update darktable to 2.4.2 and update the hash for lensfun.

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -69,7 +69,7 @@
                     "type": "git",
                     "url": "https://git.code.sf.net/p/lensfun/code",
                     "branch": "master",
-                    "commit": "b6676773a6bff40a838d8b3da259fcf9b486fa35"
+                    "commit": "505fc47dd2b7cf3769c3e6f4308872f8dcbbdea8"
                 }
             ]
         },
@@ -151,8 +151,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.4.1/darktable-2.4.1.tar.xz",
-                    "sha256": "6254c63f9b50894b3fbf431d98c0fe8ec481957ab91f9af76e33cc1201c29704"
+                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.4.2/darktable-2.4.2.tar.xz",
+                    "sha256": "19cccb60711ed0607ceaa844967b692a3b8666b12bf1d12f2242ec8942fa5a81"
                 }
             ]
         }


### PR DESCRIPTION
New darktable release today! And the hash for the master branch of lensfun needed to be updated.