### PR TITLE
Update to 2.4.3 & convert lensfun module from git to archive

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -151,8 +151,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.4.2/darktable-2.4.2.tar.xz",
-                    "sha256": "19cccb60711ed0607ceaa844967b692a3b8666b12bf1d12f2242ec8942fa5a81"
+                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.4.3/darktable-2.4.3.tar.xz",
+                    "sha256": "1dc5fc7bd142f4c74a5dd4706ac1dad772dfc7cd5538f033e60e3a08cfed03d3"
                 }
             ]
         }

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -66,10 +66,9 @@
             },
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://git.code.sf.net/p/lensfun/code",
-                    "branch": "master",
-                    "commit": "505fc47dd2b7cf3769c3e6f4308872f8dcbbdea8"
+                    "type": "archive",
+                    "url": "https://iweb.dl.sourceforge.net/project/lensfun/0.3.2/lensfun-0.3.2.tar.gz",
+                    "sha256": "ae8bcad46614ca47f5bda65b00af4a257a9564a61725df9c74cb260da544d331"
                 }
             ]
         },


### PR DESCRIPTION
This pr updates darktable to 2.4.3 and updates the lensfun module. The Sourceforge git repo seems to be down/removed so I converted it to a stable archive. It seems to build fine from it and my distro (Fedora) also uses 0.3.2 with darktable.