### PR TITLE
Add Lua support. Fixes #35.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -44,6 +44,7 @@
         "*.la"
     ],
     "modules": [
+	"shared-modules/lua5.3/lua-5.3.5.json",
         {
             "name": "lensfun",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
Use flathub's shared modules to add lua support. 