### PR TITLE
Update lensfun source URL; they've moved to github.

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -70,7 +70,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://git.code.sf.net/p/lensfun/code",
+                    "url": "https://github.com/lensfun/lensfun.git",
                     "commit": "a78b3d29762ee644bbbbb6eae9daf0b98cf84472"
                 }
             ]


### PR DESCRIPTION
Lensfun has moved their project to github. Need to update URL so the flatpak automated build doesn't fail.