### PR TITLE
Update the lensfun database when building the flatpak.

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -69,6 +69,11 @@
                     }
                 }
             },
+            "post-install": [
+                /* Remove all the lens definition files and the time stamp file */
+                "rm -rf /app/share/lensfun/version_2/*.xml",
+                "rm -rf /app/share/lensfun/version_2/timestamp.txt"
+            ],
             "sources": [
                 {
                     "type": "git",
@@ -77,6 +82,23 @@
                     "tag": "v0.3.95"
                 }
             ]
+        },
+        {
+            "name": "lensfun-db",
+            "buildsystem": "simple",
+            "build-commands": [
+                "date +%s > timestamp.txt"
+            ],
+            "post-install": [
+                /* Copy over the latest lens definition files */
+                "cp -r /run/build/lensfun-db//data/db/*.xml /app/share/lensfun/version_2/",
+		"cp /run/build/lensfun-db//timestamp.txt /app/share/lensfun/version_2/"
+            ],
+            "sources": [{
+                "type": "git",
+                "url": "https://github.com/lensfun/lensfun.git",
+                "commit": "a77fa3d7dbaeb82dd44bb863416c978b061b81a1"
+            }]
         },
         {
             "name": "exiv2",


### PR DESCRIPTION
Grab the latest lens definitions at build time, remove the lens definitions from the lensfun git repo, then replace them with the new definitions. Fixes #56.