### PR TITLE
Add PortMidi library for MIDI device input

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -142,6 +142,17 @@
             ]
         },
         {
+            "name": "portmidi",
+            "buildsystem": "cmake",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/PortMidi/portmidi/archive/refs/tags/v2.0.3.tar.gz",
+                    "sha256": "934f80e1b09762664d995e7ab5a9932033bc70639e8ceabead817183a54c60d0"
+                }
+            ]
+        },
+        {
             "name": "colord",
             "buildsystem": "meson",
             "config-opts": [

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -143,7 +143,7 @@
         },
         {
             "name": "portmidi",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Add the PortMidi library for MIDI device input. Tested with a Korg nanoKontrol2