### PR TITLE
Let darktable run commands outside the sandbox

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -18,6 +18,8 @@
         "--system-talk-name=org.freedesktop.ColorManager",
         /* Needed for gvfs to work */
         "--talk-name=org.gtk.vfs.*",
+        /* Needed so lua can call commands (e.g. exiftool) on the host system */
+        "--talk-name=org.freedesktop.Flatpak",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
         /* For USB, until there is a better way in flatpak */


### PR DESCRIPTION
See discussion on #86.

Lua scripts in darkable often call command line programs (e.g. ``exiftool``) in order to do things.  This will allow a script to reach out to the host system for these commands.

This is one possible approach for accomplishing the use case (another is pulling each command someone might want to use in a lua script into the sandbox).  One drawback of this approach is that it breaks the sandbox security model in a big way, which may or may not be important to some people.