### PR TITLE
Update libavif to 0.9.3

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -335,8 +335,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v0.9.1.tar.gz",
-                    "sha256": "8526f3fff34a05a51d7c703cdcf1d0d38c939b5b6dd4bb7d3a3405ddad88186c"
+                    "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v0.9.3.tar.gz",
+                    "sha256": "bcd9a1f57f982a9615eb7e2faf87236dc88eb1d0c886f3471c7440ead605060d"
                 }
             ]
         },


### PR DESCRIPTION
- avif export wasn't loading

See https://github.com/flathub/org.darktable.Darktable/issues/118

Close #118 