### PR TITLE
Update runtime to GNOME 47

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.darktable.Darktable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "darktable",
     "rename-desktop-file": "org.darktable.darktable.desktop",
@@ -80,8 +80,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/06/5a/e11cad7b79f2cf3dd2ff8f81fa8ca667e7591d3d8451768589996b65dec1/lxml-4.9.2.tar.gz",
-                    "sha256": "2455cfaeb7ac70338b3257f41e21f0724f4b5b0c0e7702da67ee6c3640835b67"
+                    "url": "https://files.pythonhosted.org/packages/72/14/60bf9ba4b5c6d001af3b93be17a442deea8b1ce0eab2911de839cb0dfd3f/lxml-5.0.2.tar.gz",
+                    "sha256": "6399703c40ba53e2c3b72fdb56cb908d2b83c08082ecf17de839b27e68d1e598"
                 },
                 {
                     "type": "file",
@@ -319,51 +319,6 @@
             ]
         },
         {
-            "name": "libavif",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DAVIF_CODEC_AOM=ON",
-                "-DAOM_INCLUDE_DIR=/app/include",
-                "-DAOM_LIBRARY=/app/lib/libaom.a"
-            ],
-            "cleanup": [
-                "/lib/*.so"
-            ],
-            "modules": [
-                {
-                    "name": "aom2",
-                    "buildsystem": "cmake-ninja",
-                    "builddir": true,
-                    "build-options": {
-                        "cflags": "-fPIC",
-                        "cxxflags": "-fPIC"
-                    },
-                    "config-opts": [
-                        "-DENABLE_CCACHE=1",
-                        "-DENABLE_DOCS=0",
-                        "-DENABLE_EXAMPLES=0",
-                        "-DENABLE_TESTS=0",
-                        "-DBUILD_SHARED_LIBS=NO"
-                    ],
-                    "sources": [
-                        {
-                            "type": "git",
-                            "url": "https://aomedia.googlesource.com/aom",
-                            "tag": "v3.2.0",
-                            "commit": "287164de79516c25c8c84fd544f67752c170082a"
-                        }
-                    ]
-                }
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v0.9.3.tar.gz",
-                    "sha256": "bcd9a1f57f982a9615eb7e2faf87236dc88eb1d0c886f3471c7440ead605060d"
-                }
-            ]
-        },
-        {
             "name": "libde265",
             "buildsystem": "cmake-ninja",
             "config-opts": [
@@ -396,76 +351,6 @@
                     "type": "archive",
                     "url": "https://github.com/strukturag/libheif/archive/v1.13.0.tar.gz",
                     "sha256": "50def171af4bc8991211d6027f3cee4200a86bbe60fddb537799205bf216ddca"
-                }
-            ]
-        },
-        {
-            "name": "jasper",
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-                "-DJAS_ENABLE_SHARED=ON",
-                "-DJAS_ENABLE_LIBJPEG=ON",
-                "-DJAS_ENABLE_OPENGL=OFF",
-                "-DJAS_ENABLE_DOC=OFF",
-                "-DJAS_ENABLE_PROGRAMS=OFF"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/jasper-software/jasper/archive/version-2.0.33.tar.gz",
-                    "sha256": "38b8f74565ee9e7fec44657e69adb5c9b2a966ca5947ced5717cde18a7d2eca6"
-                }
-            ]
-        },
-        {
-            "name": "libjxl",
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "config-opts": [
-                "-DBUILD_TESTING=OFF",
-                "-DJPEGXL_ENABLE_BENCHMARK=OFF",
-                "-DJPEGXL_ENABLE_DOXYGEN=OFF",
-                "-DJPEGXL_ENABLE_EXAMPLES=OFF",
-                "-DJPEGXL_ENABLE_JNI=OFF",
-                "-DJPEGXL_ENABLE_MANPAGES=OFF",
-                "-DJPEGXL_ENABLE_PLUGINS=OFF",
-                "-DJPEGXL_ENABLE_SJPEG=OFF",
-                "-DJPEGXL_ENABLE_SKCMS=OFF",
-                "-DJPEGXL_ENABLE_TCMALLOC=OFF",
-                "-DJPEGXL_ENABLE_TOOLS=OFF",
-                "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON",
-                "-DJPEGXL_FORCE_SYSTEM_HWY=ON",
-                "-DJPEGXL_FORCE_SYSTEM_LCMS2=ON",
-                "-DJPEGXL_WARNINGS_AS_ERRORS=OFF"
-            ],
-            "modules": [
-                {
-                    "name": "libhwy",
-                    "config-opts": [
-                        "-DBUILD_TESTING=OFF",
-                        "-DBUILD_SHARED_LIBS=OFF",
-                        "-DHWY_ENABLE_EXAMPLES=OFF",
-                        "-DHWY_ENABLE_TESTS=OFF",
-                        "-DHWY_FORCE_STATIC_LIBS=ON"
-                    ],
-                    "buildsystem": "cmake-ninja",
-                    "builddir": true,
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "https://github.com/google/highway/archive/refs/tags/1.0.2.tar.gz",
-                            "sha256": "e8ef71236ac0d97f12d553ec1ffc5b6375d57b5f0b860c7447dd69b6ed1072db"
-                        }
-                    ]
-                }
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libjxl/libjxl/archive/refs/tags/v0.7.0.tar.gz",
-                    "sha256": "3114bba1fabb36f6f4adc2632717209aa6f84077bc4e93b420e0d63fa0455c5e"
                 }
             ]
         },


### PR DESCRIPTION
Remove jxl, jasper and libavif as they are in the runtime Update lensfun database