### PR TITLE
Include exiv2 command line tool in sandbox

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -23,8 +23,7 @@
         "--device=all"
     ],
     "cleanup": [
-        "/include",
-        "/bin/exiv2*",
+        "/include",        
         "/bin/*lensfun*",
         "/bin/metacopy",
         "/bin/pathtest",
@@ -123,7 +122,7 @@
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DEXIV2_BUILD_DOC:BOOL=OFF",
-                "-DEXIV2_BUILD_EXIV2_COMMAND=OFF",
+                "-DEXIV2_BUILD_EXIV2_COMMAND=ON",
                 "-DEXIV2_ENABLE_BMFF=ON",
                 "-DEXIV2_BUILD_SAMPLES=OFF"
             ],


### PR DESCRIPTION
Recent changes to ``exiv2`` have fixed the issues mentioned in #98, which now makes porting the lua scripts mentioned there to use the ``exiv2`` command feasible.  But for this to work with the flatpak, we need the command line tool in the sandbox.