### PR TITLE
Update runtime to GNOME 48

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.darktable.Darktable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "darktable",
     "rename-desktop-file": "org.darktable.darktable.desktop",


### PR DESCRIPTION
Hello!
This is an attempt for updating runtime to 48.

P.S. Please also consider merging  #137 
There are several ancient libraries, even dnf pulls the same versions from that PR as dependencies.

```shell
Package                             Arch       Version                              Repository              Size
Installing:
 darktable                          x86_64     5.0.1-1.fc41                         updates             34.5 MiB
Installing dependencies:
 GraphicsMagick                     x86_64     1.3.45-1.fc41                        fedora               5.2 MiB
 colord-gtk                         x86_64     0.3.1-2.fc41                         fedora              74.9 KiB
 gmic-libs                          x86_64     3.5.2-7.fc41                         updates             14.2 MiB
 lensfun                            x86_64     0.3.4-2.fc41                         fedora               4.4 MiB
 osm-gps-map                        x86_64     1.1.0-15.fc40                        fedora             104.1 KiB
 portmidi                           x86_64     217-58.fc41                          fedora              55.7 KiB
 urw-base35-fonts-legacy            noarch     20200910-23.fc41                     fedora               4.3 MiB
``` 