### PR TITLE
Runtime cleanups

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -66,7 +66,7 @@
                 "/lib/python3.*"
             ],
             "post-install": [
-                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} lxml --ignore-installed",
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} lxml --ignore-installed --no-build-isolation",
                 "python3 lensfun_convert_db.py $PWD lensfun-git/data/db",
                 "rm -rf /app/share/lensfun/version_1/*",
                 "tar xvf db/version_1.tar -C /app/share/lensfun/version_1"


### PR DESCRIPTION
Remove libusb
It's in the runtime now.
Also remove uneeded -DCMAKE_INSTALL_LIBDIR=/app/lib for lensfun
Fix build for lxml
Sync the version of perl with the sdk.