### PR TITLE
Enable Wayland support

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -11,7 +11,8 @@
     "finish-args": [
         "--share=ipc",
         "--share=network",
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--filesystem=host",
         "--talk-name=org.freedesktop.secrets",
         "--metadata=X-DConf=migrate-path=/org/darktable/Darktable/",


### PR DESCRIPTION
Version 5.4 has Wayland support and I have been using these changes manually using Flatseal for a while.
Works very well on Gnome.