### PR TITLE
Update org.darktable.Darktable.json for AI features

### DIFF
--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -561,7 +561,8 @@
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
                 "-DBINARY_PACKAGE_BUILD=1",
-                "-DTESTBUILD_OPENCL_PROGRAMS=OFF"
+                "-DTESTBUILD_OPENCL_PROGRAMS=OFF",
+                "-DUSE_AI=ON"
             ],
             "builddir": true,
             "sources": [


### PR DESCRIPTION
Added a flag for darktable to compile with the AI features ON.

FYI, the user still needs to enable AI if they want to use the AI features and download the models. They might need to adjust flatpak settings for the models to be accessible.

https://github.com/flathub/org.darktable.Darktable/issues/241